### PR TITLE
feat: --no-rds オプションで指標 RDS ファイルの出力を省略

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Rscript r_script/00_main.R <name> <read_path> <save_path> [オプション]
 | `--cores=N`         | 1             | 並列計算コア数（72コア/512GBマシンなら `--cores=9` 程度が目安）|
 | `--metrics=A,B,...` | 全指標        | 計算する指標（`edge_density`,`umi_uei`,`ego_size`,`diameter`）|
 | `--from-tsv`        | —             | TSV から図だけ再作成（再計算しない）                          |
+| `--no-rds`          | —             | Step 3/4 の指標 RDS を保存しない（TSV のみ出力）。自動的に `--from-tsv` も有効化。I/O 節約に使用 |
 
 ### 実行例
 
@@ -137,6 +138,9 @@ Rscript r_script/00_main.R V5P2_24aB_CTCF_2 data output --metrics=ego_size,diame
 
 # 計算済み TSV から図だけ作り直す
 Rscript r_script/00_main.R V5P2_24aB_CTCF_2 data output --from-tsv
+
+# RDS 中間ファイル不要・I/O を節約したい場合（TSV と PDF のみ出力）
+Rscript r_script/00_main.R V5P2_24aB_CTCF_2 data output --no-rds 1000 --cores=9
 
 # バックグラウンドで実行（ログをファイルに保存）
 nohup Rscript r_script/00_main.R V5P2_24aB_CTCF_2 data output \
@@ -602,6 +606,25 @@ Louvain アルゴリズムはランダム初期化を使うため、同じデー
 ### Q5. SM モードと標準モードで UMI/UEI 合計が違う
 
 独立してパイプラインを実行した場合、Louvain のランダム性で大クラスターの構成が変わるため、UMI/UEI 合計が異なるのは正常です。同一クラスタリング結果での比較は `sm_bench.R` の `[PASS]/[FAIL]` で確認してください。
+
+### Q7. RDS ファイルを保存せずにパイプラインを実行したい（ストレージ・I/O 節約）
+
+`--no-rds` オプションを使います：
+
+```bash
+Rscript r_script/00_main.R V5P2_24aB_CTCF_2 data output --no-rds 1000 --cores=9
+```
+
+**保存されるファイル（変わらない）：**
+- `_01_graph.rds`, `_02_graph.rds`, `_02_membership.rds`（Step 1/2 の構造 RDS）
+- 全 TSV ファイル（`_03_*.tsv`, `_04_*.tsv`）
+- 全 PDF ファイル（`_05_*.pdf`）
+
+**省略されるファイル（5つ）：**
+- `_03_cluster_size.rds`, `_03_edge_density.rds`
+- `_04_umi_uei.rds`, `_04_ego_size.rds`, `_04_diameter.rds`
+
+TSV さえ残っていれば後から `--from-tsv` で図の再作成が可能です。Step 4 を `--no-rds` の後に単独実行する場合、`_03_cluster_size.rds` がなくても自動的に `.tsv` にフォールバックします。
 
 ### Q6. `_02_membership.rds` に `node_type` 列がない
 

--- a/r_script/00_main.R
+++ b/r_script/00_main.R
@@ -22,6 +22,10 @@
 #                      例: --metrics=ego_size,diameter
 #   --from-tsv       : 作図ステップで RDS の代わりに TSV から読み込む
 #                      計算を再実行せずに図だけ作り直す場合に使用
+#   --no-rds         : Step 3/4 の指標 RDS ファイルを保存しない（TSV のみ出力）
+#                      RDS の I/O を省略してパイプラインを高速化したい場合に使用
+#                      ※ Step 1/2 の構造 RDS（graph.rds, membership.rds）は常に保存
+#                      ※ --no-rds 指定時は自動的に --from-tsv が有効になる
 #
 # 使用例:
 #   # 全指標を計算（通常実行）
@@ -64,6 +68,7 @@ min_cluster_size <- 1000L
 num_cores        <- 1L
 metrics          <- c("edge_density", "umi_uei", "ego_size", "diameter")
 from_tsv         <- FALSE
+no_rds           <- FALSE
 
 for (a in args[-(1:3)]) {
   if (a %in% c("--no-dup", "--with-dup")) {
@@ -74,6 +79,9 @@ for (a in args[-(1:3)]) {
     metrics <- strsplit(sub("^--metrics=", "", a), ",")[[1]]
   } else if (a == "--from-tsv") {
     from_tsv <- TRUE
+  } else if (a == "--no-rds") {
+    no_rds   <- TRUE
+    from_tsv <- TRUE  # --no-rds では作図も TSV から読む
   } else if (grepl("^[0-9]+$", a)) {
     min_cluster_size <- as.integer(a)
   }
@@ -94,7 +102,8 @@ cat(paste0("  dup_mode         = ", dup_mode,                    "\n"))
 cat(paste0("  min_cluster_size = ", min_cluster_size,            "\n"))
 cat(paste0("  num_cores        = ", num_cores,                   "\n"))
 cat(paste0("  metrics          = ", paste(metrics, collapse=","), "\n"))
-cat(paste0("  from_tsv         = ", from_tsv,                    "\n\n"))
+cat(paste0("  from_tsv         = ", from_tsv,                    "\n"))
+cat(paste0("  no_rds           = ", no_rds,                      "\n\n"))
 
 # ---- ライブラリ読み込み ----
 suppressPackageStartupMessages({
@@ -136,14 +145,16 @@ run_clustering(name, save_path, num_cores = num_cores)
 # ============================================================
 cat("\n--- Step 3: Density ---\n")
 run_density(name, save_path, min_cluster_size, num_cores,
-            compute_edge_density = "edge_density" %in% metrics)
+            compute_edge_density = "edge_density" %in% metrics,
+            save_rds = !no_rds)
 
 # ============================================================
 # Step 4: その他特徴量計算
 # ============================================================
 cat("\n--- Step 4: Features ---\n")
 run_features(name, save_path, min_cluster_size, num_cores,
-             metrics = intersect(metrics, c("umi_uei", "ego_size", "diameter")))
+             metrics  = intersect(metrics, c("umi_uei", "ego_size", "diameter")),
+             save_rds = !no_rds)
 
 # ============================================================
 # Step 5: 作図

--- a/r_script/sm_00_main.R
+++ b/r_script/sm_00_main.R
@@ -18,6 +18,8 @@
 #   --cores=N        : 並列計算コア数（デフォルト: 1）
 #   --metrics=A,B,...: 計算する指標（edge_density, umi_uei, ego_size, diameter）
 #   --from-tsv       : 作図ステップで TSV から読み込む
+#   --no-rds         : Step 3/4 の指標 RDS ファイルを保存しない（TSV のみ出力）
+#                      --no-rds 指定時は自動的に --from-tsv が有効になる
 #
 # 使用例:
 #   Rscript sm_00_main.R V5P2_24aB_CTCF_2_3000 /data /output --no-dup 1000 --cores=9
@@ -39,6 +41,7 @@ min_cluster_size <- 1000L
 num_cores        <- 1L
 metrics          <- c("edge_density", "umi_uei", "ego_size", "diameter")
 from_tsv         <- FALSE
+no_rds           <- FALSE
 
 for (a in args[-(1:3)]) {
   if (a %in% c("--no-dup", "--with-dup")) {
@@ -48,6 +51,9 @@ for (a in args[-(1:3)]) {
   } else if (grepl("^--metrics=", a)) {
     metrics <- strsplit(sub("^--metrics=", "", a), ",")[[1]]
   } else if (a == "--from-tsv") {
+    from_tsv <- TRUE
+  } else if (a == "--no-rds") {
+    no_rds   <- TRUE
     from_tsv <- TRUE
   } else if (grepl("^[0-9]+$", a)) {
     min_cluster_size <- as.integer(a)
@@ -69,7 +75,8 @@ cat(paste0("  dup_mode         = ", dup_mode,                     "\n"))
 cat(paste0("  min_cluster_size = ", min_cluster_size,             "\n"))
 cat(paste0("  num_cores        = ", num_cores,                    "\n"))
 cat(paste0("  metrics          = ", paste(metrics, collapse = ","), "\n"))
-cat(paste0("  from_tsv         = ", from_tsv,                     "\n\n"))
+cat(paste0("  from_tsv         = ", from_tsv,                     "\n"))
+cat(paste0("  no_rds           = ", no_rds,                       "\n\n"))
 
 # ---- ライブラリ読み込み ----
 suppressPackageStartupMessages({
@@ -109,14 +116,16 @@ run_clustering(name, save_path, num_cores = num_cores)
 # ============================================================
 cat("\n--- Step 3: Density ---\n")
 run_density(name, save_path, min_cluster_size, num_cores,
-            compute_edge_density = "edge_density" %in% metrics)
+            compute_edge_density = "edge_density" %in% metrics,
+            save_rds = !no_rds)
 
 # ============================================================
 # Step 4: その他特徴量計算 [suffix mode: run_umi_uei が高速化]
 # ============================================================
 cat("\n--- Step 4: Features (suffix mode) ---\n")
 run_features(name, save_path, min_cluster_size, num_cores,
-             metrics = intersect(metrics, c("umi_uei", "ego_size", "diameter")))
+             metrics  = intersect(metrics, c("umi_uei", "ego_size", "diameter")),
+             save_rds = !no_rds)
 
 # ============================================================
 # Step 5: 作図


### PR DESCRIPTION
## 概要

Step 3/4 の指標 RDS ファイル（5つ）を省略できる `--no-rds` オプションを追加しました。RDS の I/O を削減し、ストレージ使用量を節約できます。

## 変更内容

### 新オプション
```bash
Rscript r_script/00_main.R <name> <read_path> <save_path> --no-rds [他オプション]
Rscript r_script/sm_00_main.R <name> <read_path> <save_path> --no-rds [他オプション]
```

### 動作
| ファイル | `--no-rds` あり | `--no-rds` なし（デフォルト） |
|---------|-----------------|-------------------------------|
| `_01_graph.rds` / `_02_*.rds` | ✓ 常に保存（構造 RDS） | ✓ 保存 |
| `_03_cluster_size.rds` | **省略** | ✓ 保存 |
| `_03_edge_density.rds` | **省略** | ✓ 保存 |
| `_04_umi_uei.rds` | **省略** | ✓ 保存 |
| `_04_ego_size.rds` | **省略** | ✓ 保存 |
| `_04_diameter.rds` | **省略** | ✓ 保存 |
| 全 TSV ファイル | ✓ 保存 | ✓ 保存 |
| 全 PDF ファイル | ✓ 保存 | ✓ 保存 |

### 実装詳細
- `03_density.R`, `04_features.R`, `sm_04_features.R` に `save_rds = TRUE` パラメーターを追加
- `--no-rds` 指定時は自動的に `--from-tsv` が有効になり Step 5 の作図も TSV から実行
- `.load_large_cluster_list()` ヘルパーを TSV フォールバック対応にすることで、`--no-rds` 実行後に Step 4 を単独再実行する場合も動作するように対応
- 個別スクリプト（`03_density.R`, `04_features.R`, `sm_04_features.R`）のスタンドアロン実行でも `--no-rds` が使用可能

## テスト確認

```
tmp/test_no_rds/ に _03_*.rds, _04_*.rds が生成されないこと ✓
TSV と PDF が正常に出力されること ✓
Step 5 が自動的に --from-tsv モードで動作すること ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)