### PR TITLE
fix: initialize no_rds and dedup_after before option parsing loop

### DIFF
--- a/r_script/00_main.R
+++ b/r_script/00_main.R
@@ -70,6 +70,7 @@ num_cores        <- 1L
 metrics          <- c("edge_density", "umi_uei", "ego_size", "diameter")
 from_tsv         <- FALSE
 no_rds           <- FALSE
+dedup_after      <- FALSE
 
 for (a in args[-(1:3)]) {
   if (a %in% c("--no-dup", "--with-dup")) {

--- a/r_script/sm_00_main.R
+++ b/r_script/sm_00_main.R
@@ -42,6 +42,7 @@ min_cluster_size <- 1000L
 num_cores        <- 1L
 metrics          <- c("edge_density", "umi_uei", "ego_size", "diameter")
 from_tsv         <- FALSE
+no_rds           <- FALSE
 dedup_after      <- FALSE
 
 for (a in args[-(1:3)]) {


### PR DESCRIPTION
- 00_main.R: add `dedup_after <- FALSE` (was undefined when --dup-then-dedup not specified)
- sm_00_main.R: add `no_rds <- FALSE` (was undefined when --no-rds not specified)

Both caused "object not found" errors when printing the startup summary.