### PR TITLE
fix: add 'sort = FALSE' in sm_02_clustering.R

### DIFF
--- a/pipeline/r_script/sm_02_clustering.R
+++ b/pipeline/r_script/sm_02_clustering.R
@@ -57,7 +57,7 @@ run_clustering <- function(name, save_path, num_cores = 1L, louvain_min_size = 3
   test_dt   <- setDT(df_list)[, .(Count = .N), by = .(to, Target2)]
   test_wide <- dcast(test_dt, to ~ Target2, value.var = "Count", fill = 0L)
   df$vertices <- merge(df$vertices, as.data.frame(test_wide),
-                       by.x = "name", by.y = "to", all.x = TRUE)
+                       by.x = "name", by.y = "to", all.x = TRUE, sort = FALSE)
   for (col in setdiff(names(df$vertices), "name")) {
     df$vertices[[col]][is.na(df$vertices[[col]])] <- 0L
   }


### PR DESCRIPTION
Related issue
#10 #11 #12 
## What was changed
sm_02_clustering.Rにsortをしないようにするoptionを加えた

## Why
型不一致エラーを防ぐため

## "V5P2_24aB_CTCF_1_S17_R1_10M"でのrunの結果
sm_00_main.Rを使用し"V5P2_24aB_CTCF_1_S17_R1_10M"のデータでrunした結果
densityもdiameterも想定通りの結果が得られ,`02_membership.rds`のnameとrownameも一致していました。

Closes #12
Closes #11 
Closes #10 